### PR TITLE
Reads raw href attribute. And supported reading of data-nav attribute.

### DIFF
--- a/Pilot.js
+++ b/Pilot.js
@@ -159,7 +159,7 @@
 				}
 
 				options.el && $(options.el).delegate('a[href],[data-nav]', 'click', _bind(this, function (evt){
-					this.nav(evt.currentTarget.href);
+					this.nav(evt.currentTarget.getAttribute('data-nav') || evt.currentTarget.getAttribute('href'));
 					evt.preventDefault();
 				}));
 			}


### PR DESCRIPTION
Чтение свойства href линка не устраивает тем, что там возвращается полный URL, а надо возвращать то, что мы написали бы в методе nav(), т.е. чистое значение.
