### PR TITLE
Up to 1.7.0

### DIFF
--- a/Pilot.js
+++ b/Pilot.js
@@ -232,10 +232,13 @@
 			this.historyIdx	= 0;
 
 			if( options.useHistory ){
-				$(window).bind('popstate hashchange', _bind(this, function (){
+				var events = (Router.pushState && history.pushState) ? 'popstate' : 'hashchange';
+				$(window).bind(events, _bind(this, function (){
 					this.nav( Router.getLocation() );
 				}));
 			}
+
+
 
 			if( options.profile ){
 				_profilerWrap(this, 'emit', true);

--- a/README.md
+++ b/README.md
@@ -887,6 +887,10 @@ Set a new location.
 <a name="changelog"></a>
 ## Changelog
 
+### 1.7.0
+
+- Event `hashchange` does not listen, if `Router.pushState` is true
+
 ### 1.6.0
 <ul>
 	<li>Removed depending on jQuery</li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pilotjs",
-	"version": "1.6.3",
+	"version": "1.7.0",
 	"devDependencies": {
 		"grunt": "~0.4.0",
 		"grunt-version": "*",


### PR DESCRIPTION
При использовании `history.pushState` событие `hashchange` роутером не обрабатывается