### PR TITLE
Игнорирование клика для Firefox, если evt.button === 2

### DIFF
--- a/src/pilot.js
+++ b/src/pilot.js
@@ -316,7 +316,7 @@ define([
 						url &&
 						hostnameRegExp.test(url) &&
 						!evt.defaultPrevented &&
-						!(evt.metaKey || evt.ctrlKey) &&
+						!(evt.metaKey || evt.ctrlKey || evt.button === 2) &&
 						(!filter || filter(url))
 					) {
 						evt.preventDefault();


### PR DESCRIPTION
[15летний баг FF](https://bugzilla.mozilla.org/show_bug.cgi?id=184051)
В Firefox при событии `contextmenu` срабатывает дополнительно лишний `click`,
который следует игнорировать.