### PR TITLE
AC-587 fix issue with urls in backUrl query params

### DIFF
--- a/Pilot.js
+++ b/Pilot.js
@@ -909,12 +909,15 @@
 			}
 		}
 
-		url = url.substr(0, 7) + url.substr(7).replace(/\/+/g, '/');
-
 		var
 			  search	= (url.split('?')[1]||'').replace(/#.*/, '')
 			, query		= _parseQueryString(search)
-			, path		= url.replace(_rrclean, '')
+		;
+
+		url = url.substr(0, 7) + url.substr(7).replace(/\/+/g, '/');
+
+		var
+			   path		= url.replace(_rrclean, '')
 			, _this		= this
 		;
 


### PR DESCRIPTION
We have issue with urls like that: `https:://somedomain.com/a/b/c?backUrl=https://somedomain.net/x/y/z` — current parser returns `https:/somedomain.net/x/y/z` for `request.query.backUrl`

